### PR TITLE
Fix ipv6 detection and typos

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -98,7 +98,7 @@ locals {
   # Ipv6 cidr block (To change when multiple Ipv6 CIDR blocks)
   vpc_ipv6_cidr_block = var.vpc_ipv6_cidr_block == null ? local.vpc.ipv6_cidr_block : var.vpc_ipv6_cidr_block
   # Checking if public subnets are dual-stack or IPv6-only
-  public_ipv6only  = can(var.subnets.public.ipv6_native)
+  public_ipv6only  = try(var.subnets.public.ipv6_native, false)
   public_dualstack = !local.public_ipv6only && (can(var.subnets.public.assign_ipv6_cidr) || can(var.subnets.public.ipv6_cidrs))
   # Checking if transit_gateway subnets are dual-stack
   tgw_dualstack = (can(var.subnets.transit_gateway.assign_ipv6_cidr) || can(var.subnets.transit_gateway.ipv6_cidrs))
@@ -106,9 +106,9 @@ locals {
   cwan_dualstack = (can(var.subnets.core_network.assign_ipv6_cidr) || can(var.subnets.core_network.ipv6_cidrs))
 
   # Egress Only Internet Gateway for IPv6
-  # list of private subnet keys with connect_to_public_eigw = true
+  # list of private subnet keys with connect_to_eigw = true
   private_subnets_egress_routed = [for type in local.private_subnet_names : type if try(var.subnets[type].connect_to_eigw == true, false)]
-  # private subnets with cidrs per az if connect_to_public_eigw = true ...  "privatetwo/us-east-1a"
+  # private subnets with cidrs per az if connect_to_eigw = true ...  "privatetwo/us-east-1a"
   private_subnet_names_egress_routed = [for subnet in local.private_per_az : subnet if contains(local.private_subnets_egress_routed, split("/", subnet)[0])]
 
   # VPC LATTICE ############################################################

--- a/modules/calculate_subnets/variables.tf
+++ b/modules/calculate_subnets/variables.tf
@@ -1,10 +1,10 @@
 variable "subnets" {
-  description = "Defition of subnets to be built. If `netmask` is passed will calculate CIDR. Else `cidrs` list is ziped to var.azs and merged into final output to be built into aws_subnet(s)."
+  description = "Definition of subnets to be built. If `netmask` is passed will calculate CIDR. Else `cidrs` list is zipped to var.azs and merged into final output to be built into aws_subnet(s)."
   type        = any
   # validation happening on root module
 }
 variable "azs" {
-  description = "List of AZs to build. AZ is appened to each IP address prefix name."
+  description = "List of AZs to build. AZ is appended to each IP address prefix name."
   type        = list(string)
 }
 

--- a/modules/calculate_subnets_ipv6/variables.tf
+++ b/modules/calculate_subnets_ipv6/variables.tf
@@ -1,10 +1,10 @@
 variable "subnets" {
-  description = "Definition of subnets to be built. If `netmask` is passed will calculate CIDR. Else `cidrs` list is ziped to var.azs and merged into final output to be built into aws_subnet(s)."
+  description = "Definition of subnets to be built. If `netmask` is passed will calculate CIDR. Else `cidrs` list is zipped to var.azs and merged into final output to be built into aws_subnet(s)."
   type        = any
   # validation happening on root module
 }
 variable "azs" {
-  description = "List of AZs to build. AZ is appened to each IP address prefix name."
+  description = "List of AZs to build. AZ is appended to each IP address prefix name."
   type        = list(string)
 }
 

--- a/tests/examples_ipv6.tftest.hcl
+++ b/tests/examples_ipv6.tftest.hcl
@@ -3,4 +3,8 @@ run "validate" {
   module {
     source = "./examples/ipv6"
   }
+  assert {
+    condition     = module.vpc.egress_only_internet_gateway.id != ""
+    error_message = "Egress-only Internet Gateway should exist in IPv6 example."
+  }
 }


### PR DESCRIPTION
## Summary
- clean up subnet description typos
- ensure ipv6-only mode detection honors explicit false
- clarify comments about egress-only internet gateway
- validate IPv6 example creates an eigw

## Testing
- `terraform test` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840ef016a7c832b89cc39039826d8c8