### PR TITLE
Add IPv6 example assertion

### DIFF
--- a/tests/examples_ipv6.tftest.hcl
+++ b/tests/examples_ipv6.tftest.hcl
@@ -3,4 +3,8 @@ run "validate" {
   module {
     source = "./examples/ipv6"
   }
+  assert {
+    condition     = module.vpc.egress_only_internet_gateway.id != ""
+    error_message = "Egress-only Internet Gateway should exist in IPv6 example."
+  }
 }


### PR DESCRIPTION
## Summary
- add missing assertion to IPv6 test

## Testing
- `terraform fmt -check -recursive` *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68410a534ba0832b889441c65581b428)